### PR TITLE
Add select

### DIFF
--- a/packages/macrame-vue3/index.d.ts
+++ b/packages/macrame-vue3/index.d.ts
@@ -2,7 +2,7 @@ import * as Macrame from '@macramejs/macrame'
 import { DefineComponent, FunctionalComponent, Plugin } from 'vue'
 import { InertiaForm } from '@inertiajs/inertia-vue3';
 
-type Data = Record<string, undefined>;
+type Data = Record<string, any|undefined>;
 type Model = Record<string, any>;
 
 export const plugin: Plugin;
@@ -64,6 +64,9 @@ export const IndexPagination : TIndexPagination;
 type TFormInput = FunctionalComponent<Macrame.FormInputProps<InertiaForm<Record<string, any>>>>;
 export const FormInput : TFormInput;
 
+type TFormSelect = FunctionalComponent<Macrame.FormSelectProps<InertiaForm<Record<string, any>>>>;
+export const FormSelect : TFormSelect;
+
 type TFormTextarea = FunctionalComponent<Macrame.FormTextareatProps<InertiaForm<Record<string, any>>>>;
 export const FormTextarea : TFormTextarea;
 
@@ -81,6 +84,9 @@ export const Textarea : TTextarea;
 
 type TInput = FunctionalComponent<Data>;
 export const Input : TInput;
+
+type TSelect = FunctionalComponent<Data>;
+export const Select : TSelect;
 
 type TCheckbox = FunctionalComponent<Data>;
 export const Checkbox : TCheckbox;

--- a/packages/macrame-vue3/src/components/FormInput.ts
+++ b/packages/macrame-vue3/src/components/FormInput.ts
@@ -7,10 +7,7 @@ const FormInput : TFormInput = function({ form, attribute, inputComponent }) {
     return h(Input, {
         ...inputComponent.props,
         modelValue: form[attribute],
-        'onUpdate:modelValue': (value) => {
-            form[attribute] = value;
-            console.log(value, form[attribute]);
-        },
+        'onUpdate:modelValue': (value) => form[attribute] = value,
     });
 }
 

--- a/packages/macrame-vue3/src/components/FormSelect.ts
+++ b/packages/macrame-vue3/src/components/FormSelect.ts
@@ -1,0 +1,14 @@
+import { resolveComponent, h } from 'vue';
+import { TFormSelect } from '../..';
+
+const FormSelect : TFormSelect = function({ form, attribute, selectComponent }) {
+    const Input = resolveComponent(selectComponent.name);
+
+    return h(Input, {
+        ...selectComponent.props,
+        modelValue: form[attribute],
+        'onUpdate:modelValue': (value) => form[attribute] = value,
+    });
+}
+
+export default FormSelect;

--- a/packages/macrame-vue3/src/components/Select.ts
+++ b/packages/macrame-vue3/src/components/Select.ts
@@ -1,0 +1,19 @@
+import { h } from 'vue';
+import { TSelect } from '../..';
+
+export const Select : TSelect = function({ options }, { attrs, emit, slots }) {
+    let children = [];
+
+    for(let value in options) {
+        children.push(h('option', { value }, options[value]));
+    }
+
+    console.log(children, options);
+
+    return h(`select`, {
+        value: attrs.modelValue,
+        onInput: ({ target }) => emit('update:modelValue', target.value),
+    }, children);
+}
+
+export default Select;

--- a/packages/macrame-vue3/src/index.js
+++ b/packages/macrame-vue3/src/index.js
@@ -4,6 +4,7 @@ export { default as FieldTitle } from './components/FieldTitle';
 export { default as useForm, Form } from './components/Form';
 export { default as FormCheckboxes } from './components/FormCheckboxes';
 export { default as FormInput } from './components/FormInput';
+export { default as FormSelect } from './components/FormSelect';
 export {
     default as useIndex,
     IndexSearch,
@@ -11,4 +12,5 @@ export {
     IndexPagination,
 } from './components/Index';
 export { default as Input } from './components/Input';
+export { default as Select } from './components/Select';
 export { Th, Td } from './components/Table';

--- a/packages/macrame/types/index.d.ts
+++ b/packages/macrame/types/index.d.ts
@@ -44,6 +44,12 @@ export declare interface FormInputProps<TForm> {
     inputComponent: Component
 }
 
+export declare interface FormSelectProps<TForm> {
+    form: TForm,
+    attribute: string,
+    selectComponent: Component
+}
+
 export declare interface FormTextareatProps<TForm> {
     form: TForm,
     attribute: string,


### PR DESCRIPTION
This pr adds a `Select` and a `FormSelect` component.

Usage:

```vue
// Select
<template>
    <base-select v-bind="$attrs" />
</template>

<script>
import { defineComponent } from 'vue';
import { Select as BaseSelect } from '@macramejs/macrame-vue3';

export default defineComponent({
    components: { BaseSelect },
});
</script>
```

```vue
// FormSelect
<template>
    <div>
        <field-title v-bind="$attrs" />
        <form-select v-bind="$attrs" />
    </div>
</template>

<script>
import { defineComponent } from 'vue';
import { FormSelect, FieldTitle } from '@macramejs/macrame-vue3';

export default defineComponent({
    components: { FormSelect, FieldTitle },
});
</script>
```