### PR TITLE
fix transition group tag breaking vue@3.2.32

### DIFF
--- a/packages/macrame-vue3/src/sections.ts
+++ b/packages/macrame-vue3/src/sections.ts
@@ -28,7 +28,6 @@ const template = `
         v-bind="dragOptions"
         :group="group"
         itemKey="uuid"
-        tag="transition-group"
         :component-data="{
             name: !drag ? 'flip-list' : null,
             wrap: true,


### PR DESCRIPTION
which caused vue draggable to crash...

When using this package with Vue.js > 3.2.31 the page-builder (Draggable component) throws en error, that causes js to crash completely.  
